### PR TITLE
Adding pinned posts to home.html

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <main class="post-list">
-  {% for post in site.posts %}
+  {% for post in site.tags.pinned %}
   <a href="{{post.url | absolute_url }}">
     <div class="card-post hidden-animation">
       <div class="card-post-meta">
@@ -23,5 +23,28 @@ layout: default
       </div>
     </div>
   </a>
+  {% endfor %}
+  {% for post in site.posts %}
+  {% unless post.tags contains 'pinned' %}
+  <a href="{{post.url | absolute_url }}">
+    <div class="card-post hidden-animation">
+      <div class="card-post-meta">
+        <h2>{{post.title}}</h2>
+        <p class="card-post-description text-secondary text-truncate">{{post.description}}</p>
+        <p class="card-post-info text-secondary">
+          <span>
+            <i class="fa-regular fa-calendar"></i>
+            <time>{{post.date | date: "%d . %m . %Y"}}</time>
+          </span>
+          <i>&bull;</i>
+          <span>
+            <i class="fa-regular fa-clock"></i>
+            {% include read-time.html content=post.content %}
+          </span>
+        </p>
+      </div>
+    </div>
+  </a>
+  {% endunless %}
   {% endfor %}
 </main>


### PR DESCRIPTION
Added in capability to have one or more "pinned" posts to the main page of the theme.  To pin a post, simply tag the post as 'pinned'.  To unpin, remove the tag.

The function adds the pinned post to the top of the post list on the home.html page and removes it from the "regular" loop based on the tag, 'pinned'.  If the post is unpinned by removing the tag, the post will fall back into the "regular" loop per the published date.